### PR TITLE
fix type definition module name

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-declare module "dll-injector" {
+declare module "dll-inject" {
   export function inject(processName: string, dllFile: string): number;
   export function injectPID(pid: number, dllFile: string): number;
   export function isProcessRunning(processName: string): boolean;


### PR DESCRIPTION
Type module was still using the previous name instead of the package's name, causing TS to never find its real module type.