### PR TITLE
Add getProcessPIDByName to get PID by name

### DIFF
--- a/functions.cc
+++ b/functions.cc
@@ -148,6 +148,17 @@ bool isProcessRunningInternalPID(DWORD pid) {
 	return true;
 }
 
+// Returns PID if a process with the given name is running, else -1
+int getProcessPIDByNameInternal(const char* processName) {
+	HANDLE process = getProcess(processName);
+	if (process == NULL) {
+		return -1;
+	}
+	int PID = GetProcessId(process);
+	CloseHandle(process);
+	return PID;
+}
+
 // Inject a DLL file into the process with the given name
 int injectInternal(const char* processName, const char* dllFile) {
 	return injectHandle(getProcess(processName), dllFile);
@@ -264,5 +275,33 @@ NAN_METHOD(isProcessRunningPID)
 	bool val = isProcessRunningInternalPID(arg);
 
 	Local<Boolean> res = Nan::New(val);
+	info.GetReturnValue().Set(res);
+}
+
+NAN_METHOD(getProcessPIDByName)
+{
+	
+	if (info.Length() != 1) {
+		return;
+	}
+	if (!info[0]->IsString()) {
+		return;
+	}
+
+	Local<Value> value;
+
+	(info[0]->ToString(Nan::GetCurrentContext())).ToLocal(&value);
+
+	String::Utf8Value arg(Isolate::GetCurrent(), value);
+
+	if (!(*arg)) {
+		return;
+	}
+
+	const char* processName = *arg;
+
+	int val = getProcessPIDByNameInternal(processName);
+
+	Local<Int32> res = Nan::New(val);
 	info.GetReturnValue().Set(res);
 }

--- a/functions.h
+++ b/functions.h
@@ -10,5 +10,6 @@ NAN_METHOD(inject);
 NAN_METHOD(injectPID);
 NAN_METHOD(isProcessRunning);
 NAN_METHOD(isProcessRunningPID);
+NAN_METHOD(getProcessPIDByName);
 
 #endif

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,5 +3,5 @@ declare module "dll-inject" {
   export function injectPID(pid: number, dllFile: string): number;
   export function isProcessRunning(processName: string): boolean;
   export function isProcessRunningPID(pid: number): boolean;
-  export function getProcessPIDByName(pid: number): number;
+  export function getProcessPIDByName(processName: string): number;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,7 @@
-declare module "dll-injector" {
+declare module "dll-inject" {
   export function inject(processName: string, dllFile: string): number;
   export function injectPID(pid: number, dllFile: string): number;
   export function isProcessRunning(processName: string): boolean;
   export function isProcessRunningPID(pid: number): boolean;
+  export function getProcessPIDByName(pid: number): number;
 }

--- a/injector.cc
+++ b/injector.cc
@@ -8,6 +8,7 @@ NAN_MODULE_INIT(InitAll) {
 	Set(target, New("injectPID").ToLocalChecked(), GetFunction(New<FunctionTemplate>(injectPID)).ToLocalChecked());
 	Set(target, New("isProcessRunning").ToLocalChecked(), GetFunction(New<FunctionTemplate>(isProcessRunning)).ToLocalChecked());
 	Set(target, New("isProcessRunningPID").ToLocalChecked(), GetFunction(New<FunctionTemplate>(isProcessRunningPID)).ToLocalChecked());
+	Set(target, New("getProcessPIDByName").ToLocalChecked(), GetFunction(New<FunctionTemplate>(getProcessPIDByName)).ToLocalChecked());
 }
 
 NODE_MODULE(injector, InitAll)


### PR DESCRIPTION
The idea is to include basic tooling to get process ID if injected DLL is using it.

In my case, injected dll creates a named pipe that includes PID, having a way to grab that while we're at it is better than having to use yet another library for it.

This is a re-PR of #6 